### PR TITLE
Feature/publish velocity

### DIFF
--- a/septentrio_gnss_driver/config/mosaic_x5_rover.param.yaml
+++ b/septentrio_gnss_driver/config/mosaic_x5_rover.param.yaml
@@ -30,7 +30,7 @@
       gprmc: false
       gpgsa: false
       gpgsv: false
-      pvtcartesian: false
+      pvtcartesian: false  # required to velocity publish
       pvtgeodetic: true  # required to navsatfix publish
       poscovcartesian: false
       poscovgeodetic: true  # required to navsatfix publish
@@ -40,4 +40,5 @@
       navsatfix: true
       gpsfix: false
       pose: false
+      velocity: false
       diagnostics: false

--- a/septentrio_gnss_driver/config/rover.yaml
+++ b/septentrio_gnss_driver/config/rover.yaml
@@ -58,5 +58,6 @@ publish:
   navsatfix: true
   gpsfix: false
   pose: false
+  velocity: false
   diagnostics: false
 

--- a/septentrio_gnss_driver/include/septentrio_gnss_driver/communication/callback_handlers.hpp
+++ b/septentrio_gnss_driver/include/septentrio_gnss_driver/communication/callback_handlers.hpp
@@ -116,6 +116,7 @@ extern bool g_publish_navsatfix;
 extern bool g_publish_gpsfix;
 extern bool g_publish_gpst;
 extern bool g_publish_pose;
+extern bool g_publish_velocity;
 extern bool g_publish_diagnostics;
 extern bool g_response_received;
 extern std::mutex g_response_mutex;

--- a/septentrio_gnss_driver/include/septentrio_gnss_driver/communication/rx_message.hpp
+++ b/septentrio_gnss_driver/include/septentrio_gnss_driver/communication/rx_message.hpp
@@ -121,6 +121,7 @@
 #include "sensor_msgs/msg/nav_sat_fix.hpp"
 #include "sensor_msgs/msg/time_reference.hpp"
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
+#include "geometry_msgs/msg/twist_with_covariance_stamped.hpp"
 #include "diagnostic_msgs/msg/diagnostic_array.hpp"
 #include "diagnostic_msgs/msg/diagnostic_status.hpp"
 #include "gps_msgs/msg/gps_fix.hpp"
@@ -181,6 +182,7 @@ extern std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::TimeReference>> g_gps
 extern std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::NavSatFix>> g_navsatfix_publisher;
 extern std::shared_ptr<rclcpp::Publisher<gps_msgs::msg::GPSFix>> g_gpsfix_publisher;
 extern std::shared_ptr<rclcpp::Publisher<geometry_msgs::msg::PoseWithCovarianceStamped>> g_posewithcovariancestamped_publisher;
+extern std::shared_ptr<rclcpp::Publisher<geometry_msgs::msg::TwistWithCovarianceStamped>> g_twistwithcovariancestamped_publisher;
 extern std::shared_ptr<rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>> g_diagnosticarray_publisher;
 extern const uint32_t g_ROS_QUEUE_SIZE;
 extern rclcpp::Time g_unix_time;

--- a/septentrio_gnss_driver/include/septentrio_gnss_driver/node/rosaic_node.hpp
+++ b/septentrio_gnss_driver/include/septentrio_gnss_driver/node/rosaic_node.hpp
@@ -93,6 +93,7 @@ extern std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::TimeReference>> g_gps
 extern std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::NavSatFix>> g_navsatfix_publisher;
 extern std::shared_ptr<rclcpp::Publisher<gps_msgs::msg::GPSFix>> g_gpsfix_publisher;
 extern std::shared_ptr<rclcpp::Publisher<geometry_msgs::msg::PoseWithCovarianceStamped>> g_posewithcovariancestamped_publisher;
+extern std::shared_ptr<rclcpp::Publisher<geometry_msgs::msg::TwistWithCovarianceStamped>> g_twistwithcovariancestamped_publisher;
 extern std::shared_ptr<rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>> g_diagnosticarray_publisher;
 extern const uint32_t g_ROS_QUEUE_SIZE;
 

--- a/septentrio_gnss_driver/launch/mosaic_x5_rover.launch.xml
+++ b/septentrio_gnss_driver/launch/mosaic_x5_rover.launch.xml
@@ -16,6 +16,7 @@
     <remap from="navsatfix" to="septentrio/nav_sat_fix" />
     <remap from="gpsfix" to="septentrio/gpsfix" />
     <remap from="pose" to="septentrio/pose" />
+    <remap from="velocity" to="septentrio/velocity" />
     <remap from="diagnostics" to="septentrio/diagnostics" />
     <param from="$(find-pkg-share septentrio_gnss_driver)/config/mosaic_x5_rover.param.yaml" />
   </node>

--- a/septentrio_gnss_driver/src/septentrio_gnss_driver/communication/rx_message.cpp
+++ b/septentrio_gnss_driver/src/septentrio_gnss_driver/communication/rx_message.cpp
@@ -1176,6 +1176,19 @@ bool io_comm_rx::RxMessage::read(std::string message_key, bool search)
 			twist_msg->twist.twist.linear.x = msg->vx;
 			twist_msg->twist.twist.linear.y = msg->vy;
 			twist_msg->twist.twist.linear.z = msg->vz;
+			if(msg->vx != -20000000000.0 && msg->vy != -20000000000.0 && msg->vz != -20000000000.0)
+			{
+					// TODO: temporary covariance value
+					twist_msg->twist.covariance[0] = 100;
+					twist_msg->twist.covariance[7] = 100;
+					twist_msg->twist.covariance[14] = 100;
+			}
+			else
+			{
+					twist_msg->twist.covariance[0] = -20000000000.0;
+					twist_msg->twist.covariance[7] = -20000000000.0;
+					twist_msg->twist.covariance[14] = -20000000000.0;
+			}
 			g_twistwithcovariancestamped_publisher->publish(*twist_msg);
 			break;
 		}

--- a/septentrio_gnss_driver/src/septentrio_gnss_driver/communication/rx_message.cpp
+++ b/septentrio_gnss_driver/src/septentrio_gnss_driver/communication/rx_message.cpp
@@ -1170,6 +1170,13 @@ bool io_comm_rx::RxMessage::read(std::string message_key, bool search)
 				}
 			}
 			g_pvtcartesian_publisher->publish(*msg);
+			septentrio_gnss_driver_msgs::msg::Gprmc::SharedPtr twist_msg = std::make_shared<septentrio_gnss_driver_msgs::msg::Gprmc>();
+			// twist_msg->header.stamp  = msg->header.stamp;
+			// twist_msg->header.frame_id = "earth";
+			// twist_msg->twist.linear.x = msg->vx;
+			// twist_msg->twist.linear.y = msg->vy;
+			// twist_msg->twist.linear.z = msg->vz;
+			// g_twistwithcovariancestamped_publisher->publish(*twist_msg);
 			break;
 		}
 		case evPVTGeodetic: // Position and velocity in geodetic coordinate frame (ENU frame)

--- a/septentrio_gnss_driver/src/septentrio_gnss_driver/communication/rx_message.cpp
+++ b/septentrio_gnss_driver/src/septentrio_gnss_driver/communication/rx_message.cpp
@@ -1170,13 +1170,13 @@ bool io_comm_rx::RxMessage::read(std::string message_key, bool search)
 				}
 			}
 			g_pvtcartesian_publisher->publish(*msg);
-			septentrio_gnss_driver_msgs::msg::Gprmc::SharedPtr twist_msg = std::make_shared<septentrio_gnss_driver_msgs::msg::Gprmc>();
-			// twist_msg->header.stamp  = msg->header.stamp;
-			// twist_msg->header.frame_id = "earth";
-			// twist_msg->twist.linear.x = msg->vx;
-			// twist_msg->twist.linear.y = msg->vy;
-			// twist_msg->twist.linear.z = msg->vz;
-			// g_twistwithcovariancestamped_publisher->publish(*twist_msg);
+			geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr twist_msg = std::make_shared<geometry_msgs::msg::TwistWithCovarianceStamped>();
+			twist_msg->header.stamp  = msg->header.stamp;
+			twist_msg->header.frame_id = "earth";
+			twist_msg->twist.twist.linear.x = msg->vx;
+			twist_msg->twist.twist.linear.y = msg->vy;
+			twist_msg->twist.twist.linear.z = msg->vz;
+			g_twistwithcovariancestamped_publisher->publish(*twist_msg);
 			break;
 		}
 		case evPVTGeodetic: // Position and velocity in geodetic coordinate frame (ENU frame)

--- a/septentrio_gnss_driver/src/septentrio_gnss_driver/node/rosaic_node.cpp
+++ b/septentrio_gnss_driver/src/septentrio_gnss_driver/node/rosaic_node.cpp
@@ -45,6 +45,7 @@ rosaic_node::ROSaicNode::ROSaicNode() : Node("septentrio_gnss")
 	g_publish_navsatfix = declare_parameter<bool>("publish.navsatfix", true);
 	g_publish_gpsfix = declare_parameter<bool>("publish.gpsfix", true);
 	g_publish_pose = declare_parameter<bool>("publish.pose", true);
+	g_publish_velocity = declare_parameter<bool>("publish.velocity", true);
 	g_publish_diagnostics = declare_parameter<bool>("publish.diagnostics", true);
 	int leap_seconds = declare_parameter<int>("leap_seconds", 18);
 	getROSInt("leap_seconds", g_leap_seconds, static_cast<uint32_t>(18), leap_seconds);
@@ -720,6 +721,15 @@ void rosaic_node::ROSaicNode::defineMessages()
 		IO.handlers_.callbackmap_ = IO.getHandlers().insert<geometry_msgs::msg::PoseWithCovarianceStamped>("PoseWithCovarianceStamped");
 		g_posewithcovariancestamped_publisher = create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>("pose", durable_qos);
 	}
+	if (g_publish_velocity == true)
+	{
+		if (publish_pvtcartesian_ == false)
+		{
+			RCLCPP_ERROR(this->get_logger(), "For a proper TwistWithCovarianceStamped message, please set the publish/pvtcartesian ROSaic parameters  to true.");
+		}
+		IO.handlers_.callbackmap_ = IO.getHandlers().insert<geometry_msgs::msg::TwistWithCovarianceStamped>("TwistWithCovarianceStamped");
+		g_twistwithcovariancestamped_publisher = create_publisher<geometry_msgs::msg::TwistWithCovarianceStamped>("velocity", durable_qos);
+	}
 	if (g_publish_diagnostics == true)
 	{
 		IO.handlers_.callbackmap_ = IO.getHandlers().insert<diagnostic_msgs::msg::DiagnosticArray>("DiagnosticArray");
@@ -745,6 +755,8 @@ bool g_publish_navsatfix;
 bool g_publish_gpsfix;
 //! Whether or not to publish the geometry_msgs::PoseWithCovarianceStamped message
 bool g_publish_pose;
+//! Whether or not to publish the geometry_msgs::TwistWithCovarianceStamped message
+bool g_publish_velocity;
 //! Whether or not to publish the diagnostic_msgs::DiagnosticArray message
 bool g_publish_diagnostics;
 //! The frame ID used in the header of every published ROS message
@@ -830,6 +842,7 @@ std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::TimeReference>> g_gpst_publi
 std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::NavSatFix>> g_navsatfix_publisher;
 std::shared_ptr<rclcpp::Publisher<gps_msgs::msg::GPSFix>> g_gpsfix_publisher;
 std::shared_ptr<rclcpp::Publisher<geometry_msgs::msg::PoseWithCovarianceStamped>> g_posewithcovariancestamped_publisher;
+std::shared_ptr<rclcpp::Publisher<geometry_msgs::msg::TwistWithCovarianceStamped>> g_twistwithcovariancestamped_publisher;
 std::shared_ptr<rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>> g_diagnosticarray_publisher;
 //! You must initialize the NodeHandle in the "main" function (or in any method called 
 //! indirectly or directly by the main function). 


### PR DESCRIPTION
This is a pull request to make eagleye autoware compliant.
・Eagleye requires GNSS Doppler velocity as input.
・The specification in Autoware requires that the velocity output from the GNSS driver be TwistWithCovarianceStamped.
https://github.com/autowarefoundation/autoware_msgs/tree/main/autoware_sensing_msgs#velocity

To output TwistWithCovarianceStamped, publish.pvtcartesian and publish.velocity in the yaml file must be set to true.
